### PR TITLE
Filepicker file highlighting

### DIFF
--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -123,6 +123,7 @@ def add_game_exe(game: Game, callback: typing.Callable = None):
                 start_dir /= best_match
     utils.push_popup(filepicker.FilePicker(
         title=f"Select or drop executable for {game.name}",
+        picker_type=filepicker.PickerType.Execs,
         start_dir=start_dir,
         callback=select_callback,
         buttons=[use_uri]

--- a/modules/db.py
+++ b/modules/db.py
@@ -205,6 +205,7 @@ async def connect():
             "style_corner_radius":         f'INTEGER DEFAULT {DefaultStyle.corner_radius}',
             "style_text":                  f'TEXT    DEFAULT "{DefaultStyle.text}"',
             "style_text_dim":              f'TEXT    DEFAULT "{DefaultStyle.text_dim}"',
+            "style_filepicker_highlight":  f'TEXT    DEFAULT "{DefaultStyle.filepicker_highlight}"',
             "tags_highlights":             f'TEXT    DEFAULT "{{}}"',
             "timestamp_format":            f'TEXT    DEFAULT "%d/%m/%Y %H:%M"',
             "use_parser_processes":        f'INTEGER DEFAULT {int(True)}',

--- a/modules/filepicker.py
+++ b/modules/filepicker.py
@@ -210,7 +210,10 @@ class FilePicker:
                     imgui.text(self.error)
             else:
                 imgui.set_next_item_width(width)
-                imgui.push_style_color(imgui.COLOR_HEADER, *style.colors[imgui.COLOR_BUTTON_HOVERED])  # added
+                header_color = (*style.colors[imgui.COLOR_BUTTON_HOVERED][:3], 0.3)
+                imgui.push_style_color(imgui.COLOR_HEADER, *header_color)  # added
+                imgui.push_style_color(imgui.COLOR_HEADER_HOVERED, *header_color)  # added
+                imgui.push_style_color(imgui.COLOR_HEADER_ACTIVE, *header_color)  # added
                 with imgui.begin_list_box(f"###file_list", height=height) as listbox:
                     if listbox.opened:
                         for i, item in enumerate(self.items):
@@ -218,7 +221,7 @@ class FilePicker:
                             if imgui.selectable(item.display(), self.current == i)[0]:
                                 self.current = i
                             imgui.pop_style_color()
-                imgui.pop_style_color()  # added
+                imgui.pop_style_color(3)  # added
             if self.current != -1:
                 self.current = min(max(self.current, 0), len(self.items) - 1)
                 item = self.items[self.current]

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1913,6 +1913,7 @@ class MainGUI():
                             game.set_image_sync(pathlib.Path(selected).read_bytes())
                     utils.push_popup(filepicker.FilePicker(
                         title=f"Select or drop image for {game.name}",
+                        picker_type=filepicker.PickerType.Media,
                         callback=select_callback
                     ).tick)
                 if imgui.selectable(f"{icons.trash_can_outline} Reset image", False)[0]:
@@ -3891,6 +3892,7 @@ class MainGUI():
                                     async_thread.run(db.update_settings("browser_custom_executable"))
                             utils.push_popup(filepicker.FilePicker(
                                 title="Select or drop browser executable",
+                                picker_type=filepicker.PickerType.Execs,
                                 start_dir=set.browser_custom_executable,
                                 callback=callback
                             ).tick)
@@ -4278,6 +4280,7 @@ class MainGUI():
                     buttons={
                         f"{icons.check} Ok": lambda: utils.push_popup(filepicker.FilePicker(
                                                          title="Select or drop bookmark file",
+                                                         picker_type=filepicker.PickerType.Bookmarks,
                                                          callback=callback
                                                      ).tick),
                         f"{icons.cancel} Cancel": None
@@ -4574,15 +4577,19 @@ class MainGUI():
             draw_settings_label("Text dim:")
             draw_settings_color("style_text_dim")
 
+            draw_settings_label("Filepicker highlight:")
+            draw_settings_color("style_filepicker_highlight")
+
             draw_settings_label("Defaults:")
             if imgui.button("Restore", width=right_width):
                 set.style_corner_radius = DefaultStyle.corner_radius
-                set.style_accent        = colors.hex_to_rgba_0_1(DefaultStyle.accent)
-                set.style_alt_bg        = colors.hex_to_rgba_0_1(DefaultStyle.alt_bg)
-                set.style_bg            = colors.hex_to_rgba_0_1(DefaultStyle.bg)
-                set.style_border        = colors.hex_to_rgba_0_1(DefaultStyle.border)
-                set.style_text          = colors.hex_to_rgba_0_1(DefaultStyle.text)
-                set.style_text_dim      = colors.hex_to_rgba_0_1(DefaultStyle.text_dim)
+                set.style_accent               = colors.hex_to_rgba_0_1(DefaultStyle.accent)
+                set.style_alt_bg               = colors.hex_to_rgba_0_1(DefaultStyle.alt_bg)
+                set.style_bg                   = colors.hex_to_rgba_0_1(DefaultStyle.bg)
+                set.style_border               = colors.hex_to_rgba_0_1(DefaultStyle.border)
+                set.style_text                 = colors.hex_to_rgba_0_1(DefaultStyle.text)
+                set.style_text_dim             = colors.hex_to_rgba_0_1(DefaultStyle.text_dim)
+                set.style_filepicker_highlight = colors.hex_to_rgba_0_1(DefaultStyle.filepicker_highlight)
                 self.refresh_styles()
                 async_thread.run(db.update_settings(
                     "style_corner_radius",
@@ -4592,6 +4599,7 @@ class MainGUI():
                     "style_border",
                     "style_text",
                     "style_text_dim",
+                    "style_filepicker_highlight",
                 ))
 
             imgui.end_table()

--- a/modules/structs.py
+++ b/modules/structs.py
@@ -171,13 +171,14 @@ class Datestamp(Timestamp):
 
 
 class DefaultStyle:
-    accent        = "#d4202e"
-    alt_bg        = "#101010"
-    bg            = "#0a0a0a"
-    border        = "#454545"
-    corner_radius = 6
-    text          = "#ffffff"
-    text_dim      = "#808080"
+    accent               = "#d4202e"
+    alt_bg               = "#101010"
+    bg                   = "#0a0a0a"
+    border               = "#454545"
+    corner_radius        = 6
+    text                 = "#ffffff"
+    text_dim             = "#808080"
+    filepicker_highlight = "#80FF00"
 
 
 @dataclasses.dataclass
@@ -675,6 +676,7 @@ class Settings:
     style_corner_radius         : int
     style_text                  : tuple[float]
     style_text_dim              : tuple[float]
+    style_filepicker_highlight  : tuple[float]
     tags_highlights             : dict[Tag, TagHighlight]
     timestamp_format            : str
     use_parser_processes        : bool


### PR DESCRIPTION
sorry for dumping everything in one commit, installed new git tool today and accidentally messed up my history with a hotkey
here is an overview to compensate:

1. refactored filepicker a little bit
   1. reimplemented listbox with `begin_listbox` to override item styles
   2. abstracted list item into a class `ListItem` which handles styles and holds some other stuff which was previously computed inline `is_dir` `is_file` `path` etc.
   3. added `PickerType` enum and wrapped old `dir_picker` field with `PickerType.Dirs` variant
   4. errors are now handled separately from the list items, previoulsy they were written to the item list
2. added new database/settings entry for file picker higlighting style color
3. changed the outline folder icon variant to a filled one because the old one was blending in with the file icons, making it harder to distinguish between them imo (you can see the change on first screenshot).

highlighting happens based on picker type and extension, `PickerType.Execs` will only highlight executables, `PickerType.Media` only media, etc. i wanted to use mimetypes detection for this feature but turns out that `python-magic` requires custom libmagic dlls for windows and pure python `filetype` package is extremely limited at the moment.

| execs | media | errors |
|--------|--------|--------|
| ![image](https://github.com/Willy-JL/F95Checker/assets/153987701/08aafc1d-ffb9-4aaf-b822-b8435b2da0d0) | ![image](https://github.com/Willy-JL/F95Checker/assets/153987701/5f6902ba-483a-436f-ad3f-51ff223231e3) | ![image](https://github.com/Willy-JL/F95Checker/assets/153987701/83615c55-01d3-4f67-a6cc-cf424944d5f7) | 

P.S. i noticed that you've added comments like `# added` and `# changed` in reference to the gist. i'm not sure what purpose they serve. perhaps it's time to remove them? it should be sufficient to leave the first comment pointing to the gist itself.

