### PR TITLE
Sort Labels on F95Checker launch

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -437,6 +437,7 @@ async def load():
     cursor = await connection.execute("""
         SELECT *
         FROM labels
+        ORDER BY lower(name)
     """)
     for label in await cursor.fetchall():
         Label.add(row_to_cls(label, Label))


### PR DESCRIPTION
Something I also forgot to make a PR for... following up on an old request from GrammarCop

I tried every which way from Sunday to add sorting when adding labels but couldn't find a way that didn't crash.
Mentioned this before in one of my Discord DM's.

I would have used `COLLATE NOCASE` instead of `lower(name)` but seems the used SQLite version doesn't support it.
