### PR TITLE
Fix window not restoring when shown from a non-main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix launching ELF binaries on Linux (by @WillyJL)
 - Fix notification daemon spinning when main process dies (by @WillyJL)
 - Fix images with 0ms durations freezing the program (by @WillyJL)
+- Fix window show/hide from other threads and from tray icon (by @cicklolwut & @WillyJL)
 
 ### Removed:
 - Nothing

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -805,18 +805,15 @@ class MainGUI():
     def hidden(self):
         return not glfw.get_window_attrib(self.window, glfw.VISIBLE)
 
-    def hide(self, *_, **__):
-        if threading.current_thread() is not threading.main_thread():
-            self.call_soon.append(self.hide)
-            return
+    def _hide(self, *_, **__):
         self.screen_pos = glfw.get_window_pos(self.window)
         glfw.hide_window(self.window)
         self.tray.update_status()
 
-    def show(self, *_, **__):
-        if threading.current_thread() is not threading.main_thread():
-            self.call_soon.append(self.show)
-            return
+    def hide(self, *_, **__):
+        self.call_soon.append(self._hide)
+
+    def _show(self, *_, **__):
         self.bg_mode_timer = None
         self.bg_mode_notifs_timer = None
         # if not self.hidden:
@@ -826,6 +823,9 @@ class MainGUI():
             glfw.set_window_pos(self.window, *self.screen_pos)
         glfw.focus_window(self.window)
         self.tray.update_status()
+
+    def show(self, *_, **__):
+        self.call_soon.append(self._show)
 
     def scaled(self, size: int | float):
         return _scaled(globals.settings.interface_scaling, size)

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -808,6 +808,7 @@ class MainGUI():
     def hide(self, *_, **__):
         if threading.current_thread() is not threading.main_thread():
             self.call_soon.append(self.hide)
+            return
         self.screen_pos = glfw.get_window_pos(self.window)
         glfw.hide_window(self.window)
         self.tray.update_status()
@@ -815,6 +816,7 @@ class MainGUI():
     def show(self, *_, **__):
         if threading.current_thread() is not threading.main_thread():
             self.call_soon.append(self.show)
+            return
         self.bg_mode_timer = None
         self.bg_mode_notifs_timer = None
         # if not self.hidden:


### PR DESCRIPTION
show() and hide() append themselves to call_soon when called off the main thread, but did not return, so they also ran the GLFW calls inline on the calling thread. glfwShowWindow then flips GLFW's internal visibility flag without the window ever being mapped, so the queued main-thread call early-returns as a no-op and the window stays off-screen while the app believes it is visible.