### PR TITLE
Restrict RPC server CORS to the browser addon and f95zone.to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix notification daemon spinning when main process dies (by @WillyJL)
 - Fix images with 0ms durations freezing the program (by @WillyJL)
 - Fix window show/hide from other threads and from tray icon (by @cicklolwut & @WillyJL)
+- Restrict RPC server CORS to the browser addon and f95zone.to (by @cicklolwut)
 
 ### Removed:
 - Nothing

--- a/modules/rpc_thread.py
+++ b/modules/rpc_thread.py
@@ -22,6 +22,25 @@ from modules import (
     utils,
 )
 
+EXTENSION_SCHEMES = (
+    "moz-extension://",
+    "chrome-extension://",
+    "safari-web-extension://",
+)
+ALLOWED_WEB_ORIGINS = (
+    "https://f95zone.to",
+    "https://www.f95zone.to",
+)
+
+
+def origin_allowed(origin: str | None):
+    if not origin:
+        return True
+    if origin.startswith(EXTENSION_SCHEMES):
+        return True
+    return origin in ALLOWED_WEB_ORIGINS
+
+
 server: socketserver.TCPServer = None
 thread: threading.Thread = None
 
@@ -48,18 +67,35 @@ def start():
             if not globals.debug:
                 log_message = lambda *_, **__: None
 
+            def deny_origin(self):
+                if origin_allowed(self.headers.get("Origin")):
+                    return False
+                self.send_response(403)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"Origin not allowed")
+                return True
+
+            def send_cors(self):
+                origin = self.headers.get("Origin")
+                if origin:
+                    self.send_header("Access-Control-Allow-Origin", origin)
+                    self.send_header("Vary", "Origin")
+
             def do_OPTIONS(self):
+                if self.deny_origin():
+                    return
                 self.send_response(200, "ok")
-                self.send_header('Access-Control-Allow-Origin', '*')
-                self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-                self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
-                self.send_header("Access-Control-Allow-Headers", "Content-Type")
-                self.send_header("Access-Control-Allow-Private-Network", "true")
+                self.send_cors()
+                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "X-Requested-With, Content-Type")
+                if self.headers.get("Access-Control-Request-Private-Network") == "true":
+                    self.send_header("Access-Control-Allow-Private-Network", "true")
                 self.end_headers()
 
             def send_resp(self, code: int, content_type: str = "application/octet-stream", headers: dict[str, str] = {}):
                 self.send_response(code)
-                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_cors()
                 self.send_header("Content-Type", content_type)
                 for key, value in headers.items():
                     self.send_header(key, value)
@@ -70,6 +106,8 @@ def start():
                 self.wfile.write(json.dumps(data).encode())
 
             def do_GET(self):
+                if self.deny_origin():
+                    return
                 try:
                     match self.path:
                         case "/games":
@@ -102,6 +140,8 @@ def start():
                     self.send_resp(500)
 
             def do_POST(self):
+                if self.deny_origin():
+                    return
                 try:
                     match self.path:
                         case "/window/show":


### PR DESCRIPTION
The RPC server answers every request with `Access-Control-Allow-Origin: *`, and
sends `Access-Control-Allow-Private-Network: true` on preflights. It listens on
localhost with no auth and is enabled by default, so any page the user happens
to visit can read `GET /games`, which returns each game's thread id and notes,
and can call the POST endpoints (however unlikely that might be).

Tested with the addon on Firefox, which sends
`Origin: moz-extension://<uuid>`, and by calling the endpoints from a page on
another origin.

Considered a shared token between the app and the extension (or in-app approval, but no storage scope on extension for key management); would be stricter, but needs a setup
step from every user, and the case worth closing here is a random page
reading the library, which this handles