### PR TITLE
Show launch state on the play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Added:
-- Nothing
+- Show launch state on the play button (by @cicklolwut)
 
 ### Updated:
 - Nothing

--- a/common/structs.py
+++ b/common/structs.py
@@ -568,6 +568,13 @@ ExeState = IntEnumHack("ExeState", [
 ])
 
 
+LaunchState = IntEnumHack("LaunchState", [
+    ("Idle",     1),
+    ("Starting", 2),
+    ("Playing",  3),
+])
+
+
 MsgBox = IntEnumHack("MsgBox", [
     ("info",  (1, {"color": (0.10, 0.69, 0.95), "icon": "information"})),
     ("warn",  (2, {"color": (0.95, 0.69, 0.10), "icon": "alert_rhombus"})),

--- a/common/structs.py
+++ b/common/structs.py
@@ -975,6 +975,9 @@ class Game:
     reviews_total      : int
     reviews            : list[Review]
     selected           : bool = False
+    launch_state       : str = ""
+    launch_started     : float = 0.0
+    launch_process     : typing.Any = None
     image              : "imagehelper.ImageHelper" = None
     executables_valids : list[bool] = None
     executables_valid  : bool = None

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -190,10 +190,13 @@ async def _launch_exe(executable: str):
         open_webpage(exe.as_uri())
         return
 
+    windows_exe_magics = (b"MZ", b"ZM", b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1")  # .exe and .msi
+    unix_exe_magics = (b"#!", b"\x7FELF")  # Shebang and ELF
     if globals.os is Os.Windows:
         with exe.open("rb") as f:
-            exe_magic = f.read(8).startswith((b"MZ", b"ZM"))
+            exe_magic = f.read(8).startswith(windows_exe_magics)
         if exe_magic:
+            # Run as executable and get PID
             try:
                 return await asyncio.create_subprocess_exec(
                     str(exe),
@@ -210,8 +213,7 @@ async def _launch_exe(executable: str):
         mode = exe.stat().st_mode
         exe_flag = not (mode & stat.S_IEXEC < stat.S_IEXEC)
         with exe.open("rb") as f:
-            # Check for shebang, exe and msi magic numbers
-            exe_magic = f.read(8).startswith((b"#!", b"\x7FELF", b"MZ", b"ZM", b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1"))
+            exe_magic = f.read(8).startswith((*unix_exe_magics, *windows_exe_magics))
         if exe_magic and not exe_flag:
             # Should be executable but isn't, fix it
             exe.chmod(mode | stat.S_IEXEC)
@@ -224,7 +226,7 @@ async def _launch_exe(executable: str):
                     if mode & stat.S_IEXEC < stat.S_IEXEC:
                         file.chmod(mode | stat.S_IEXEC)
         if exe_magic and exe_flag:
-            # Run as executable
+            # Run as executable and get PID
             return await asyncio.create_subprocess_exec(
                 str(exe),
                 cwd=str(exe.parent),

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -17,6 +17,7 @@ import imgui
 
 from common.structs import (
     Game,
+    LaunchState,
     MsgBox,
     Os,
     SearchResult,
@@ -246,7 +247,7 @@ def _track_launch(game: Game, process):
     global launch_state_changed
     game.launch_process = process
     game.launch_started = time.time()
-    game.launch_state = "starting"
+    game.launch_state = LaunchState.Starting
     launch_state_changed = True
 
     async def watch():
@@ -293,7 +294,7 @@ def _track_launch(game: Game, process):
                 break
         else:
             if game.launch_process is process:
-                game.launch_state = "playing"
+                game.launch_state = LaunchState.Playing
                 launch_state_changed = True
             while process.returncode is None or tree_alive():
                 if process.returncode is None:
@@ -304,7 +305,7 @@ def _track_launch(game: Game, process):
                 else:
                     await asyncio.sleep(1)
         if game.launch_process is process:
-            game.launch_state = ""
+            game.launch_state = LaunchState.Idle
             game.launch_started = 0.0
             game.launch_process = None
             launch_state_changed = True

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -4,6 +4,7 @@ import difflib
 import os
 import pathlib
 import plistlib
+import psutil
 import re
 import shlex
 import stat
@@ -189,6 +190,19 @@ async def _launch_exe(executable: str):
         return
 
     if globals.os is Os.Windows:
+        with exe.open("rb") as f:
+            exe_magic = f.read(8).startswith((b"MZ", b"ZM"))
+        if exe_magic:
+            try:
+                return await asyncio.create_subprocess_exec(
+                    str(exe),
+                    cwd=str(exe.parent),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+            except OSError:
+                pass
         # Open with default app
         await default_open(str(exe), cwd=str(exe.parent))
     else:
@@ -210,7 +224,7 @@ async def _launch_exe(executable: str):
                         file.chmod(mode | stat.S_IEXEC)
         if exe_magic and exe_flag:
             # Run as executable
-            await asyncio.create_subprocess_exec(
+            return await asyncio.create_subprocess_exec(
                 str(exe),
                 cwd=str(exe.parent),
                 stdin=subprocess.DEVNULL,
@@ -222,9 +236,85 @@ async def _launch_exe(executable: str):
             await default_open(str(exe), cwd=str(exe.parent))
 
 
+playing_grace_seconds = 3
+launch_state_changed = False
+
+
+def _track_launch(game: Game, process):
+    if process is None:
+        return
+    global launch_state_changed
+    game.launch_process = process
+    game.launch_started = time.time()
+    game.launch_state = "starting"
+    launch_state_changed = True
+
+    async def watch():
+        global launch_state_changed
+        tree = {}
+
+        def remember(proc):
+            try:
+                tree[(proc.pid, proc.create_time())] = proc
+            except psutil.Error:
+                pass
+
+        def scan():
+            pids = {pid for pid, _ in tree}
+            try:
+                for proc in psutil.process_iter(("pid", "ppid")):
+                    if proc.info["ppid"] in pids and proc.pid not in pids:
+                        remember(proc)
+            except psutil.Error:
+                pass
+
+        def tree_alive():
+            scan()
+            for proc in tree.values():
+                try:
+                    if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                        return True
+                except psutil.Error:
+                    pass
+            return False
+
+        try:
+            remember(psutil.Process(process.pid))
+        except psutil.Error:
+            pass
+        deadline = time.time() + playing_grace_seconds
+        while time.time() < deadline:
+            try:
+                await asyncio.wait_for(asyncio.shield(process.wait()), timeout=0.25)
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+            scan()
+            if process.returncode is not None and not tree_alive():
+                break
+        else:
+            if game.launch_process is process:
+                game.launch_state = "playing"
+                launch_state_changed = True
+            while process.returncode is None or tree_alive():
+                if process.returncode is None:
+                    try:
+                        await asyncio.wait_for(asyncio.shield(process.wait()), timeout=1)
+                    except (asyncio.TimeoutError, TimeoutError):
+                        pass
+                else:
+                    await asyncio.sleep(1)
+        if game.launch_process is process:
+            game.launch_state = ""
+            game.launch_started = 0.0
+            game.launch_process = None
+            launch_state_changed = True
+
+    async_thread.run(watch())
+
+
 async def _launch_game_exe(game: Game, executable: str):
     try:
-        await _launch_exe(executable)
+        _track_launch(game, await _launch_exe(executable))
         game.last_launched = time.time()
         exe = pathlib.Path(executable)
         if utils.is_uri(executable):

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -912,10 +912,10 @@ class MainGUI():
                         or api.session.connector._acquired
                         or prev_focused != self.focused
                         or prev_hidden != self.hidden
-                        or launch_changed
                         or size != self.prev_size
                         or self.recalculate_ids
                         or self.new_styles
+                        or launch_changed
                         or api.updating
                     )
                     if draw:

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -36,6 +36,7 @@ from common.structs import (
     FilterMode,
     Game,
     Label,
+    LaunchState,
     MsgBox,
     Os,
     ProxyType,
@@ -1327,18 +1328,20 @@ class MainGUI():
                 valid = game.executables_valid
             if not valid:
                 imgui.push_style_color(imgui.COLOR_TEXT, 0.87, 0.20, 0.20)
-        launch_state = game.launch_state if game else ""
-        if launch_state == "starting":
+        launch_state = game.launch_state if game else LaunchState.Idle
+        if launch_state is LaunchState.Starting:
             label = label.replace(" Play", " Starting")
             imgui.push_style_color(imgui.COLOR_TEXT, 0.95, 0.75, 0.20)
-        elif launch_state == "playing":
+        elif launch_state is LaunchState.Playing:
             label = label.replace(" Play", " Playing")
             imgui.push_style_color(imgui.COLOR_TEXT, 0.30, 0.85, 0.35)
+        else:
+            launch_state = LaunchState.Idle  # Make sure we don't imgui.pop_style_color() after
         if selectable:
             clicked = imgui.selectable(label, False)[0]
         else:
             clicked = imgui.button(label)
-        if launch_state:
+        if launch_state is not LaunchState.Idle:
             imgui.pop_style_color()
         if game and (not game.executables or not valid):
             imgui.pop_style_color()

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -896,6 +896,8 @@ class MainGUI():
                         imgui.io.mouse_wheel = scroll_now
 
                     # Redraw only when needed
+                    launch_changed = callbacks.launch_state_changed
+                    callbacks.launch_state_changed = False
                     draw = (
                         (api.downloads and any(dl.state in (dl.State.Verifying, dl.State.Extracting) for dl in api.downloads.values()))
                         or (imagehelper.redraw and globals.settings.play_gifs and (self.focused or globals.settings.play_gifs_unfocused))
@@ -907,6 +909,7 @@ class MainGUI():
                         or api.session.connector._acquired
                         or prev_focused != self.focused
                         or prev_hidden != self.hidden
+                        or launch_changed
                         or size != self.prev_size
                         or self.recalculate_ids
                         or self.new_styles
@@ -1322,10 +1325,19 @@ class MainGUI():
                 valid = game.executables_valid
             if not valid:
                 imgui.push_style_color(imgui.COLOR_TEXT, 0.87, 0.20, 0.20)
+        launch_state = game.launch_state if game else ""
+        if launch_state == "starting":
+            label = label.replace(" Play", " Starting")
+            imgui.push_style_color(imgui.COLOR_TEXT, 0.95, 0.75, 0.20)
+        elif launch_state == "playing":
+            label = label.replace(" Play", " Playing")
+            imgui.push_style_color(imgui.COLOR_TEXT, 0.30, 0.85, 0.35)
         if selectable:
             clicked = imgui.selectable(label, False)[0]
         else:
             clicked = imgui.button(label)
+        if launch_state:
+            imgui.pop_style_color()
         if game and (not game.executables or not valid):
             imgui.pop_style_color()
         if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ beautifulsoup4==4.12.3
 lxml==5.3.0
 
 # Misc
+psutil==7.2.2
 pywin32==308 ; sys_platform == "win32"
 bencode2==0.3.17
 pillow==11.0.0


### PR DESCRIPTION
launching a game keeps no handle on the process, so a game that is starting slowly and one that never started (or crashed) look the same. not likely an issue for most windows users, but very handy when testing different proton versions on linux (and at this point, a few lines of code away from being able to track playtime, if so desired)

The play button now reads `Starting` while the process comes up, `Playing` once it
has stayed alive a few seconds, and goes back to `Play` when it exits. the whole
process tree is followed, since some games launch through a stub that starts
the real game and quits. the interface only redraws when something asks for
it, so the watcher raises a flag the frame loop consumes, otherwise the label
would sit stale until the window next got focus.

On Windows everything used to go through os.startfile, which returns nothing,
so nothing could be followed there. Real executables are now spawned directly
like on linux, and anything else, or an executable that needs elevation, still
goes through the shell like before. those launches keep the plain `Play` label:
the shell hands back no process, and something like an html game opening as a
tab in an already running browser has no process of its own at all. replacing
startfile with ShellExecuteEx later would hand back a pid even for elevated
launches and resolve .lnk shortcuts properly, but that felt like its own pr.

psutil moves into requirements, it was only ever pulled in through py7zr.

Tested on Linux with several games, including one that launches through a
Loader.exe which quits after starting the real game, the button stays on
Playing until the game itself exits, and keeps updating while the window is
unfocused. Tested on Windows 10 with a plain exe (tracked through its whole
lifetime), a .lnk and an html file (shell fallback, plain label), and an exe
requiring elevation (UAC prompt shows, launches fine, plain label).