### PR TITLE
Track playtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Added:
 - Show launch state on the play button (by @cicklolwut)
+- Locally tracked playtime duration (by @cicklolwut)
 
 ### Updated:
 - Nothing

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ An update checker and library tool for (NSFW) games on the [F95zone](https://f95
   - Forum score (value out of 5) and personal rating (5 stars)
   - Forum reviews (20 most recents)
   - Personal notes (textbox you can use however you want)
+  - Locally tracked playtime duration
   - Most of these details, and some extras, tracked in a local timeline
 - Sorting and filtering by most of above details, with multisort and multifilter support
 - Tag highlighting to quickly spot content you might like and what to avoid

--- a/common/structs.py
+++ b/common/structs.py
@@ -568,6 +568,13 @@ ExeState = IntEnumHack("ExeState", [
 ])
 
 
+LaunchState = IntEnumHack("LaunchState", [
+    ("Idle",     1),
+    ("Starting", 2),
+    ("Playing",  3),
+])
+
+
 MsgBox = IntEnumHack("MsgBox", [
     ("info",  (1, {"color": (0.10, 0.69, 0.95), "icon": "information"})),
     ("warn",  (2, {"color": (0.95, 0.69, 0.10), "icon": "alert_rhombus"})),

--- a/common/structs.py
+++ b/common/structs.py
@@ -953,6 +953,7 @@ class Game:
     last_full_check    : int
     last_check_version : str
     last_launched      : Datestamp
+    playtime           : float
     score              : float
     votes              : int
     rating             : int
@@ -977,6 +978,7 @@ class Game:
     selected           : bool = False
     launch_state       : str = ""
     launch_started     : float = 0.0
+    launch_flushed     : float = 0.0
     launch_process     : typing.Any = None
     image              : "imagehelper.ImageHelper" = None
     executables_valids : list[bool] = None
@@ -1140,6 +1142,7 @@ class Game:
             "last_full_check",
             "last_check_version",
             "last_launched",
+            "playtime",
             "score",
             "votes",
             "rating",

--- a/common/structs.py
+++ b/common/structs.py
@@ -1128,6 +1128,19 @@ class Game:
         async_thread.run(db.create_timeline_event(self.id, Timestamp(time.time()), list(args), type))
 
 
+    @property
+    def playtime_display(self):
+        playtime = self.playtime
+        if self.launch_state and self.launch_started:
+            playtime += time.time() - self.launch_started - self.launch_flushed
+        if playtime >= 3600:
+            return f"{playtime / 3600:.1f}h"
+        if playtime >= 60:
+            return f"{int(playtime / 60)}m"
+        if playtime:
+            return "<1m"
+        return ""
+
     def __setattr__(self, name: str, value: typing.Any):
         if hasattr(self, "_did_init") and self._did_init and name in [
             "custom",

--- a/common/structs.py
+++ b/common/structs.py
@@ -975,6 +975,9 @@ class Game:
     reviews_total      : int
     reviews            : list[Review]
     selected           : bool = False
+    launch_state       : str = ""
+    launch_started     : float = 0.0
+    launch_process     : typing.Any = None
     image              : "imagehelper.ImageHelper" = None
     executables_valids : list[bool] = None
     executables_valid  : bool = None

--- a/common/structs.py
+++ b/common/structs.py
@@ -983,7 +983,7 @@ class Game:
     reviews_total      : int
     reviews            : list[Review]
     selected           : bool = False
-    launch_state       : str = ""
+    launch_state       : LaunchState = LaunchState.Idle
     launch_started     : float = 0.0
     launch_flushed     : float = 0.0
     launch_process     : typing.Any = None
@@ -1138,7 +1138,7 @@ class Game:
     @property
     def playtime_display(self):
         playtime = self.playtime
-        if self.launch_state and self.launch_started:
+        if self.launch_state is not LaunchState.Idle and self.launch_started:
             playtime += time.time() - self.launch_started - self.launch_flushed
         if playtime >= 3600:
             return f"{playtime / 3600:.1f}h"

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -290,12 +290,14 @@ def _track_launch(game: Game, process):
 
         def flush_playtime():
             nonlocal flushed
+            global launch_state_changed
             if game.launch_process is not process:
                 return
             session = time.time() - session_start
             game.playtime += session - flushed
             flushed = session
             game.launch_flushed = flushed
+            launch_state_changed = True
 
         deadline = time.time() + playing_grace_seconds
         while time.time() < deadline:

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -282,6 +282,18 @@ def _track_launch(game: Game, process):
             remember(psutil.Process(process.pid))
         except psutil.Error:
             pass
+        session_start = time.time()
+        flushed = 0.0
+
+        def flush_playtime():
+            nonlocal flushed
+            if game.launch_process is not process:
+                return
+            session = time.time() - session_start
+            game.playtime += session - flushed
+            flushed = session
+            game.launch_flushed = flushed
+
         deadline = time.time() + playing_grace_seconds
         while time.time() < deadline:
             try:
@@ -303,9 +315,13 @@ def _track_launch(game: Game, process):
                         pass
                 else:
                     await asyncio.sleep(1)
+                if time.time() - session_start - flushed >= 60:
+                    flush_playtime()
+        flush_playtime()
         if game.launch_process is process:
             game.launch_state = ""
             game.launch_started = 0.0
+            game.launch_flushed = 0.0
             game.launch_process = None
             launch_state_changed = True
 

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -190,10 +190,13 @@ async def _launch_exe(executable: str):
         open_webpage(exe.as_uri())
         return
 
+    windows_exe_magics = (b"MZ", b"ZM", b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1")  # .exe and .msi
+    unix_exe_magics = (b"#!", b"\x7FELF")  # Shebang and ELF
     if globals.os is Os.Windows:
         with exe.open("rb") as f:
-            exe_magic = f.read(8).startswith((b"MZ", b"ZM"))
+            exe_magic = f.read(8).startswith(windows_exe_magics)
         if exe_magic:
+            # Run as executable and get PID
             try:
                 return await asyncio.create_subprocess_exec(
                     str(exe),
@@ -210,8 +213,7 @@ async def _launch_exe(executable: str):
         mode = exe.stat().st_mode
         exe_flag = not (mode & stat.S_IEXEC < stat.S_IEXEC)
         with exe.open("rb") as f:
-            # Check for shebang, exe and msi magic numbers
-            exe_magic = f.read(8).startswith((b"#!", b"\x7FELF", b"MZ", b"ZM", b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1"))
+            exe_magic = f.read(8).startswith((*unix_exe_magics, *windows_exe_magics))
         if exe_magic and not exe_flag:
             # Should be executable but isn't, fix it
             exe.chmod(mode | stat.S_IEXEC)
@@ -224,7 +226,7 @@ async def _launch_exe(executable: str):
                     if mode & stat.S_IEXEC < stat.S_IEXEC:
                         file.chmod(mode | stat.S_IEXEC)
         if exe_magic and exe_flag:
-            # Run as executable
+            # Run as executable and get PID
             return await asyncio.create_subprocess_exec(
                 str(exe),
                 cwd=str(exe.parent),

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -17,6 +17,7 @@ import imgui
 
 from common.structs import (
     Game,
+    LaunchState,
     MsgBox,
     Os,
     SearchResult,
@@ -246,7 +247,7 @@ def _track_launch(game: Game, process):
     global launch_state_changed
     game.launch_process = process
     game.launch_started = time.time()
-    game.launch_state = "starting"
+    game.launch_state = LaunchState.Starting
     launch_state_changed = True
 
     async def watch():
@@ -305,7 +306,7 @@ def _track_launch(game: Game, process):
                 break
         else:
             if game.launch_process is process:
-                game.launch_state = "playing"
+                game.launch_state = LaunchState.Playing
                 launch_state_changed = True
             while process.returncode is None or tree_alive():
                 if process.returncode is None:
@@ -319,7 +320,7 @@ def _track_launch(game: Game, process):
                     flush_playtime()
         flush_playtime()
         if game.launch_process is process:
-            game.launch_state = ""
+            game.launch_state = LaunchState.Idle
             game.launch_started = 0.0
             game.launch_flushed = 0.0
             game.launch_process = None

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -4,6 +4,7 @@ import difflib
 import os
 import pathlib
 import plistlib
+import psutil
 import re
 import shlex
 import stat
@@ -189,6 +190,19 @@ async def _launch_exe(executable: str):
         return
 
     if globals.os is Os.Windows:
+        with exe.open("rb") as f:
+            exe_magic = f.read(8).startswith((b"MZ", b"ZM"))
+        if exe_magic:
+            try:
+                return await asyncio.create_subprocess_exec(
+                    str(exe),
+                    cwd=str(exe.parent),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+            except OSError:
+                pass
         # Open with default app
         await default_open(str(exe), cwd=str(exe.parent))
     else:
@@ -210,7 +224,7 @@ async def _launch_exe(executable: str):
                         file.chmod(mode | stat.S_IEXEC)
         if exe_magic and exe_flag:
             # Run as executable
-            await asyncio.create_subprocess_exec(
+            return await asyncio.create_subprocess_exec(
                 str(exe),
                 cwd=str(exe.parent),
                 stdin=subprocess.DEVNULL,
@@ -222,9 +236,85 @@ async def _launch_exe(executable: str):
             await default_open(str(exe), cwd=str(exe.parent))
 
 
+playing_grace_seconds = 3
+launch_state_changed = False
+
+
+def _track_launch(game: Game, process):
+    if process is None:
+        return
+    global launch_state_changed
+    game.launch_process = process
+    game.launch_started = time.time()
+    game.launch_state = "starting"
+    launch_state_changed = True
+
+    async def watch():
+        global launch_state_changed
+        tree = {}
+
+        def remember(proc):
+            try:
+                tree[(proc.pid, proc.create_time())] = proc
+            except psutil.Error:
+                pass
+
+        def scan():
+            pids = {pid for pid, _ in tree}
+            try:
+                for proc in psutil.process_iter(("pid", "ppid")):
+                    if proc.info["ppid"] in pids and proc.pid not in pids:
+                        remember(proc)
+            except psutil.Error:
+                pass
+
+        def tree_alive():
+            scan()
+            for proc in tree.values():
+                try:
+                    if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                        return True
+                except psutil.Error:
+                    pass
+            return False
+
+        try:
+            remember(psutil.Process(process.pid))
+        except psutil.Error:
+            pass
+        deadline = time.time() + playing_grace_seconds
+        while time.time() < deadline:
+            try:
+                await asyncio.wait_for(asyncio.shield(process.wait()), timeout=0.25)
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+            scan()
+            if process.returncode is not None and not tree_alive():
+                break
+        else:
+            if game.launch_process is process:
+                game.launch_state = "playing"
+                launch_state_changed = True
+            while process.returncode is None or tree_alive():
+                if process.returncode is None:
+                    try:
+                        await asyncio.wait_for(asyncio.shield(process.wait()), timeout=1)
+                    except (asyncio.TimeoutError, TimeoutError):
+                        pass
+                else:
+                    await asyncio.sleep(1)
+        if game.launch_process is process:
+            game.launch_state = ""
+            game.launch_started = 0.0
+            game.launch_process = None
+            launch_state_changed = True
+
+    async_thread.run(watch())
+
+
 async def _launch_game_exe(game: Game, executable: str):
     try:
-        await _launch_exe(executable)
+        _track_launch(game, await _launch_exe(executable))
         game.last_launched = time.time()
         exe = pathlib.Path(executable)
         if utils.is_uri(executable):

--- a/modules/db.py
+++ b/modules/db.py
@@ -305,6 +305,7 @@ async def connect():
             "last_full_check":             f'INTEGER DEFAULT 0',
             "last_check_version":          f'TEXT    DEFAULT ""',
             "last_launched":               f'INTEGER DEFAULT 0',
+            "playtime":                    f'REAL    DEFAULT 0',
             "score":                       f'REAL    DEFAULT 0',
             "votes":                       f'INTEGER DEFAULT 0',
             "rating":                      f'INTEGER DEFAULT 0',

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -915,10 +915,10 @@ class MainGUI():
                         or api.session.connector._acquired
                         or prev_focused != self.focused
                         or prev_hidden != self.hidden
-                        or launch_changed
                         or size != self.prev_size
                         or self.recalculate_ids
                         or self.new_styles
+                        or launch_changed
                         or api.updating
                     )
                     if draw:

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -3679,9 +3679,8 @@ class MainGUI():
         if cols.score.enabled:
             _cluster_text(cols.score.name, f"{game.score:.1f} ({game.votes})")
             self.draw_hover_text(f"Weighted: {utils.bayesian_average(game.score, game.votes):.2f}", text=None)
-        if cols.playtime.enabled and not drag_drop and game.playtime_display:
+        if cols.playtime.enabled and game.playtime_display:
             _cluster_text(cols.playtime.name, game.playtime_display)
-            imgui.dummy(0, 0)
         if cols.last_updated.enabled:
             _cluster_text(cols.last_updated.name, game.last_updated.display or "Unknown")
         if cols.last_launched.enabled:
@@ -3712,8 +3711,6 @@ class MainGUI():
                     _cluster_text(cols.finished_version.name, game.finished)
                 if cols.installed_version.enabled and game.installed:
                     _cluster_text(cols.installed_version.name, game.installed)
-        if cols.playtime.enabled and drag_drop and game.playtime_display:
-            _cluster_text(cols.playtime.name, game.playtime_display)
         if cluster:
             imgui.dummy(0, 0)
         # Notes line

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -251,9 +251,10 @@ class Columns:
             short_header=True,
         )
         self.playtime = self.Column(
-            self, f"{icons.timer_outline} Playtime",
+            self, f"{icons.timer_play_outline} Playtime",
             sortable=True,
             resizable=False,
+            short_header=True,
         )
 
 cols = Columns()
@@ -2332,10 +2333,8 @@ class MainGUI():
                     game.last_launched = time.time()
                     game.add_timeline_event(TimelineEventType.GameLaunched, "date set manually")
                 self.draw_hover_text("Click to set as launched right now!", text=None)
-
-                imgui.table_next_row()
-                imgui.table_next_column()
-                imgui.text_disabled("Playtime:")
+                imgui.same_line(spacing=0)
+                imgui.text_disabled(", Playtime:")
                 imgui.same_line()
                 imgui.text(game.playtime_display or "None")
 

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -182,6 +182,11 @@ class Columns:
             self, f"{icons.account} Developer",
             sortable=True,
         )
+        self.playtime = self.Column(
+            self, f"{icons.timer_outline} Playtime",
+            sortable=True,
+            resizable=False,
+        )
         self.last_updated = self.Column(
             self, f"{icons.update} Last Updated",
             default=True,
@@ -2327,17 +2332,7 @@ class MainGUI():
                 imgui.table_next_column()
                 imgui.text_disabled("Playtime:")
                 imgui.same_line()
-                playtime = game.playtime
-                if game.launch_state and game.launch_started:
-                    playtime += time.time() - game.launch_started - game.launch_flushed
-                if playtime >= 3600:
-                    imgui.text(f"{playtime / 3600:.1f}h")
-                elif playtime >= 60:
-                    imgui.text(f"{int(playtime / 60)}m")
-                elif playtime:
-                    imgui.text("<1m")
-                else:
-                    imgui.text("None")
+                imgui.text(game.playtime_display or "None")
 
                 imgui.table_next_row()
 
@@ -3169,6 +3164,8 @@ class MainGUI():
                             key = lambda id: globals.games[id].type.name
                         case cols.developer.index:
                             key = lambda id: globals.games[id].developer.lower()
+                        case cols.playtime.index:
+                            key = lambda id: - globals.games[id].playtime
                         case cols.last_updated.index:
                             key = lambda id: - globals.games[id].last_updated.value
                         case cols.last_launched.index:
@@ -3386,6 +3383,10 @@ class MainGUI():
                                 imgui.text_disabled("  |  ".join(versions))
                         case cols.developer.index:
                             imgui.text(game.developer or "Unknown")
+                        case cols.playtime.index:
+                            imgui.push_font(imgui.fonts.mono)
+                            imgui.text(game.playtime_display or "None")
+                            imgui.pop_font()
                         case cols.last_updated.index:
                             imgui.push_font(imgui.fonts.mono)
                             imgui.text(game.last_updated.display or "Unknown")
@@ -3671,6 +3672,9 @@ class MainGUI():
         if cols.score.enabled:
             _cluster_text(cols.score.name, f"{game.score:.1f} ({game.votes})")
             self.draw_hover_text(f"Weighted: {utils.bayesian_average(game.score, game.votes):.2f}", text=None)
+        if cols.playtime.enabled and not drag_drop and game.playtime_display:
+            _cluster_text(cols.playtime.name, game.playtime_display)
+            imgui.dummy(0, 0)
         if cols.last_updated.enabled:
             _cluster_text(cols.last_updated.name, game.last_updated.display or "Unknown")
         if cols.last_launched.enabled:
@@ -3701,6 +3705,8 @@ class MainGUI():
                     _cluster_text(cols.finished_version.name, game.finished)
                 if cols.installed_version.enabled and game.installed:
                     _cluster_text(cols.installed_version.name, game.installed)
+        if cols.playtime.enabled and drag_drop and game.playtime_display:
+            _cluster_text(cols.playtime.name, game.playtime_display)
         if cluster:
             imgui.dummy(0, 0)
         # Notes line

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -183,11 +183,6 @@ class Columns:
             self, f"{icons.account} Developer",
             sortable=True,
         )
-        self.playtime = self.Column(
-            self, f"{icons.timer_outline} Playtime",
-            sortable=True,
-            resizable=False,
-        )
         self.last_updated = self.Column(
             self, f"{icons.update} Last Updated",
             default=True,
@@ -254,6 +249,11 @@ class Columns:
             sortable=True,
             resizable=False,
             short_header=True,
+        )
+        self.playtime = self.Column(
+            self, f"{icons.timer_outline} Playtime",
+            sortable=True,
+            resizable=False,
         )
 
 cols = Columns()

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -896,6 +896,8 @@ class MainGUI():
                         imgui.io.mouse_wheel = scroll_now
 
                     # Redraw only when needed
+                    launch_changed = callbacks.launch_state_changed
+                    callbacks.launch_state_changed = False
                     draw = (
                         (api.downloads and any(dl.state in (dl.State.Verifying, dl.State.Extracting) for dl in api.downloads.values()))
                         or (imagehelper.redraw and globals.settings.play_gifs and (self.focused or globals.settings.play_gifs_unfocused))
@@ -907,6 +909,7 @@ class MainGUI():
                         or api.session.connector._acquired
                         or prev_focused != self.focused
                         or prev_hidden != self.hidden
+                        or launch_changed
                         or size != self.prev_size
                         or self.recalculate_ids
                         or self.new_styles
@@ -1322,10 +1325,19 @@ class MainGUI():
                 valid = game.executables_valid
             if not valid:
                 imgui.push_style_color(imgui.COLOR_TEXT, 0.87, 0.20, 0.20)
+        launch_state = game.launch_state if game else ""
+        if launch_state == "starting":
+            label = label.replace(" Play", " Starting")
+            imgui.push_style_color(imgui.COLOR_TEXT, 0.95, 0.75, 0.20)
+        elif launch_state == "playing":
+            label = label.replace(" Play", " Playing")
+            imgui.push_style_color(imgui.COLOR_TEXT, 0.30, 0.85, 0.35)
         if selectable:
             clicked = imgui.selectable(label, False)[0]
         else:
             clicked = imgui.button(label)
+        if launch_state:
+            imgui.pop_style_color()
         if game and (not game.executables or not valid):
             imgui.pop_style_color()
         if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -2324,6 +2324,22 @@ class MainGUI():
                 self.draw_hover_text("Click to set as launched right now!", text=None)
 
                 imgui.table_next_row()
+                imgui.table_next_column()
+                imgui.text_disabled("Playtime:")
+                imgui.same_line()
+                playtime = game.playtime
+                if game.launch_state and game.launch_started:
+                    playtime += time.time() - game.launch_started - game.launch_flushed
+                if playtime >= 3600:
+                    imgui.text(f"{playtime / 3600:.1f}h")
+                elif playtime >= 60:
+                    imgui.text(f"{int(playtime / 60)}m")
+                elif playtime:
+                    imgui.text("<1m")
+                else:
+                    imgui.text("None")
+
+                imgui.table_next_row()
 
                 imgui.table_next_column()
                 imgui.text_disabled("Forum Score:")

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -36,6 +36,7 @@ from common.structs import (
     FilterMode,
     Game,
     Label,
+    LaunchState,
     MsgBox,
     Os,
     ProxyType,
@@ -1330,18 +1331,20 @@ class MainGUI():
                 valid = game.executables_valid
             if not valid:
                 imgui.push_style_color(imgui.COLOR_TEXT, 0.87, 0.20, 0.20)
-        launch_state = game.launch_state if game else ""
-        if launch_state == "starting":
+        launch_state = game.launch_state if game else LaunchState.Idle
+        if launch_state is LaunchState.Starting:
             label = label.replace(" Play", " Starting")
             imgui.push_style_color(imgui.COLOR_TEXT, 0.95, 0.75, 0.20)
-        elif launch_state == "playing":
+        elif launch_state is LaunchState.Playing:
             label = label.replace(" Play", " Playing")
             imgui.push_style_color(imgui.COLOR_TEXT, 0.30, 0.85, 0.35)
+        else:
+            launch_state = LaunchState.Idle  # Make sure we don't imgui.pop_style_color() after
         if selectable:
             clicked = imgui.selectable(label, False)[0]
         else:
             clicked = imgui.button(label)
-        if launch_state:
+        if launch_state is not LaunchState.Idle:
             imgui.pop_style_color()
         if game and (not game.executables or not valid):
             imgui.pop_style_color()

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ beautifulsoup4==4.12.3
 lxml==5.3.0
 
 # Misc
+psutil==7.2.2
 pywin32==308 ; sys_platform == "win32"
 bencode2==0.3.17
 pillow==11.0.0


### PR DESCRIPTION
Builds on #288, the first commit here is that PR, the playtime changes are the
two commits on top.

The launch watcher from #288 already knows when a game's process tree comes up
and when it dies, so the time between now accumulates into a per game total,
flushed to the database every minute so a crash loses at most that much.

It shows in the info popup next to Last Launched, counting the current session
live, and as an optional sortable column, default off: next to Last Updated in
the list view, at the end of the details cluster on grid cards, and on its own
line above the dates on kanban cards. Cards skip it while it is zero, and
sorting puts the most played first.

Totals survive app restarts and accumulate across sessions, including games
running under wine or a compatibility runner, where the whole process tree is
timed. Draft mostly for the column placements, which could use a design
once-over.
