### PR TITLE
Add custom label ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - clicking Play will open all files in your media player
 - Show launch state on the play button (#288 by @cicklolwut)
 - Locally tracked playtime duration (#290 by @cicklolwut)
+- Label reordering (#291 by @px-pole & WillyJL)
 
 ### Updated:
 - Animations (Video and GIF) and Comics (CG, Comics, Manga and Pinup) thread types are detected properly now, "Collection" and "SiteRip" prefixes are now ignored (by @WillyJL)

--- a/common/structs.py
+++ b/common/structs.py
@@ -674,6 +674,7 @@ class Label:
     id: int
     name: str
     color: tuple[float]
+    position: int
     instances: typing.ClassVar = []
 
     @property
@@ -700,6 +701,16 @@ class Label:
     def remove(cls, self):
         while self in cls.instances:
             cls.instances.remove(self)
+
+    @classmethod
+    def update_positions(cls):
+        for self_i, self in enumerate(cls.instances):
+            self.position = self_i
+
+    @classmethod
+    def sort_instances(cls):
+        cls.instances.sort(key=lambda self: self.position)
+        cls.update_positions()
 
 
 @dataclasses.dataclass(slots=True)
@@ -998,6 +1009,7 @@ class Game:
 
     def __post_init__(self):
         self._did_init = True
+        self.labels.sort(key=lambda label: Label.instances.index(label))
         if self.custom is None:
             self.custom = bool(self.status is Status.Custom)
         if self.id < 0:

--- a/common/structs.py
+++ b/common/structs.py
@@ -1009,7 +1009,7 @@ class Game:
 
     def __post_init__(self):
         self._did_init = True
-        self.labels.sort(key=lambda label: Label.instances.index(label))
+        self.labels.sort(key=lambda label: label.position)
         if self.custom is None:
             self.custom = bool(self.status is Status.Custom)
         if self.id < 0:
@@ -1128,7 +1128,7 @@ class Game:
     def add_label(self, label: Label):
         if label not in self.labels:
             self.labels.append(label)
-        self.labels.sort(key=lambda label: Label.instances.index(label))
+        self.labels.sort(key=lambda label: label.position)
         from external import async_thread
         from modules import db, globals
         async_thread.run(db.update_game(self, "labels"))

--- a/modules/db.py
+++ b/modules/db.py
@@ -47,6 +47,7 @@ from modules import (
 )
 
 connection: aiosqlite.Connection = None
+label_positions_lock: asyncio.Lock = None
 
 
 @contextlib.contextmanager
@@ -159,7 +160,7 @@ async def create_table(table_name: str, columns: dict[str, str], renames: list[t
 
 
 async def connect():
-    global connection
+    global connection, label_positions_lock
 
     db_path = globals.data_path / "db.sqlite3"
 
@@ -185,6 +186,7 @@ async def connect():
 
     migrate = not db_path.is_file()
     connection = await aiosqlite.connect(db_path)
+    label_positions_lock = asyncio.Lock()
     connection.row_factory = aiosqlite.Row  # Return sqlite3.Row instead of tuple
 
     await create_table(
@@ -654,10 +656,13 @@ async def update_label(label: Label, *keys: list[str]):
     """, tuple(values))
 
 
-async def update_label_positions():
-    Label.update_positions()
-    for label in Label.instances:
-        await update_label(label, "position")
+async def update_label_positions(positions: tuple[tuple[int, int], ...]):
+    async with label_positions_lock:
+        await connection.executemany("""
+            UPDATE labels
+            SET position=?
+            WHERE id=?
+        """, positions)
 
 
 async def delete_label(label: Label):
@@ -672,7 +677,9 @@ async def delete_label(label: Label):
         if flt.match is label:
             globals.gui.filters.remove(flt)
     Label.remove(label)
-    await update_label_positions()
+    Label.update_positions()
+    positions = tuple((label.position, label.id) for label in Label.instances)
+    await update_label_positions(positions)
 
 
 async def create_label():

--- a/modules/db.py
+++ b/modules/db.py
@@ -354,6 +354,7 @@ async def connect():
             "id":                          f'INTEGER PRIMARY KEY AUTOINCREMENT',
             "name":                        f'TEXT    DEFAULT ""',
             "color":                       f'TEXT    DEFAULT "#696969"',
+            "position":                    f'INTEGER DEFAULT 0',
         }
     )
     await create_table(
@@ -474,9 +475,11 @@ async def load():
     cursor = await connection.execute("""
         SELECT *
         FROM labels
+        ORDER BY id
     """)
     for label in await cursor.fetchall():
         Label.add(row_to_cls(label, Label))
+    Label.sort_instances()
 
     cursor = await connection.execute("""
         SELECT *
@@ -651,6 +654,12 @@ async def update_label(label: Label, *keys: list[str]):
     """, tuple(values))
 
 
+async def update_label_positions():
+    Label.update_positions()
+    for label in Label.instances:
+        await update_label(label, "position")
+
+
 async def delete_label(label: Label):
     await connection.execute(f"""
         DELETE FROM labels
@@ -663,18 +672,21 @@ async def delete_label(label: Label):
         if flt.match is label:
             globals.gui.filters.remove(flt)
     Label.remove(label)
+    await update_label_positions()
 
 
 async def create_label():
     cursor = await connection.execute(f"""
         INSERT INTO labels
-        DEFAULT VALUES
-    """)
+        (position)
+        VALUES
+        (?)
+    """, (len(Label.instances),))
     cursor = await connection.execute(f"""
         SELECT *
         FROM labels
-        WHERE id={cursor.lastrowid}
-    """)
+        WHERE id=?
+    """, (cursor.lastrowid,))
     label = row_to_cls(await cursor.fetchone(), Label)
     Label.add(label)
     return label

--- a/modules/db.py
+++ b/modules/db.py
@@ -656,8 +656,9 @@ async def update_label(label: Label, *keys: list[str]):
     """, tuple(values))
 
 
-async def update_label_positions(positions: tuple[tuple[int, int], ...]):
+async def update_label_positions():
     async with label_positions_lock:
+        positions = tuple((label.position, label.id) for label in Label.instances)
         await connection.executemany("""
             UPDATE labels
             SET position=?
@@ -678,8 +679,7 @@ async def delete_label(label: Label):
             globals.gui.filters.remove(flt)
     Label.remove(label)
     Label.update_positions()
-    positions = tuple((label.position, label.id) for label in Label.instances)
-    await update_label_positions(positions)
+    await update_label_positions()
 
 
 async def create_label():

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -4727,8 +4727,9 @@ class MainGUI():
             imgui.spacing()
 
         if draw_settings_section("Labels"):
-            buttons_offset = right_width - (3 * frame_height + 2 * imgui.style.item_spacing.x)
-            for label in Label.instances:
+            buttons_offset = right_width - (5 * frame_height + 4 * imgui.style.item_spacing.x)
+            swap = None
+            for label_i, label in enumerate(Label.instances):
                 imgui.table_next_row()
                 imgui.table_next_column()
                 imgui.set_next_item_width(imgui.get_content_region_available_width() + buttons_offset + imgui.style.cell_padding.x)
@@ -4747,13 +4748,34 @@ class MainGUI():
                     label.color = (*value, 1.0)
                     async_thread.run(db.update_label(label, "color"))
                 imgui.same_line()
-                if imgui.button(icons.filter_plus_outline, width=frame_height):
+                if label_i == 0:
+                    imgui.push_disabled()
+                if imgui.button(f"{icons.arrow_up}###label_up_{label.id}", width=frame_height):
+                    swap = (label_i, label_i - 1)
+                if label_i == 0:
+                    imgui.pop_disabled()
+                imgui.same_line()
+                if label_i == len(Label.instances) - 1:
+                    imgui.push_disabled()
+                if imgui.button(f"{icons.arrow_down}###label_down_{label.id}", width=frame_height):
+                    swap = (label_i, label_i + 1)
+                if label_i == len(Label.instances) - 1:
+                    imgui.pop_disabled()
+                imgui.same_line()
+                if imgui.button(f"{icons.filter_plus_outline}###label_filter_{label.id}", width=frame_height):
                     flt = Filter(FilterMode.Label)
                     flt.match = label
                     self.filters.append(flt)
                 imgui.same_line()
-                if imgui.button(icons.trash_can_outline, width=frame_height):
+                if imgui.button(f"{icons.trash_can_outline}###label_delete_{label.id}", width=frame_height):
                     async_thread.run(db.delete_label(label))
+
+            if swap:
+                Label.instances[swap[0]], Label.instances[swap[1]] = Label.instances[swap[1]], Label.instances[swap[0]]
+                Label.update_positions()
+                for game in globals.games.values():
+                    game.labels.sort(key=lambda label: Label.instances.index(label))
+                async_thread.run(db.update_label_positions())
 
             draw_settings_label("New label:")
             if imgui.button("Add", width=right_width):

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -751,6 +751,15 @@ class MainGUI():
         try:
             with open(globals.data_path / "filters.pkl", "rb") as file:
                 self.filters = pickle.load(file)
+                for flt in self.filters:
+                    match flt.mode:
+                        case FilterMode.Label:
+                            # Field added later, replace broken object with real one
+                            if not hasattr(flt.match, "position"):
+                                try:
+                                    flt.match = Label.get(flt.match.id)
+                                except Exception:
+                                    self.filters.remove(flt)
         except Exception:
             self.filters = []
 

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -4736,12 +4736,35 @@ class MainGUI():
             imgui.spacing()
 
         if draw_settings_section("Labels"):
-            buttons_offset = right_width - (5 * frame_height + 4 * imgui.style.item_spacing.x)
             swap = None
             for label_i, label in enumerate(Label.instances):
                 imgui.table_next_row()
                 imgui.table_next_column()
-                imgui.set_next_item_width(imgui.get_content_region_available_width() + buttons_offset + imgui.style.cell_padding.x)
+                if imgui.button(icons.filter_plus_outline, width=frame_height):
+                    flt = Filter(FilterMode.Label)
+                    flt.match = label
+                    self.filters.append(flt)
+                imgui.same_line()
+                if label_i == 0:
+                    imgui.push_disabled()
+                if imgui.button(icons.arrow_up, width=frame_height):
+                    swap = (label_i, label_i - 1)
+                if label_i == 0:
+                    imgui.pop_disabled()
+                imgui.same_line()
+                if label_i == len(Label.instances) - 1:
+                    imgui.push_disabled()
+                if imgui.button(icons.arrow_down, width=frame_height):
+                    swap = (label_i, label_i + 1)
+                if label_i == len(Label.instances) - 1:
+                    imgui.pop_disabled()
+                imgui.same_line()
+                changed, value = imgui.color_edit3(f"###label_color_{label.id}", *label.color[:3], flags=imgui.COLOR_EDIT_NO_INPUTS)
+                if changed:
+                    label.color = (*value, 1.0)
+                    async_thread.run(db.update_label(label, "color"))
+                imgui.same_line()
+                imgui.set_next_item_width(width - frame_height * 5 - imgui.style.cell_padding.x * 5 - imgui.style.scrollbar_size * (imgui.get_scroll_max_y() > 0.0))
                 changed, value = imgui.input_text_with_hint(f"###label_name_{label.id}", "Label name", label.name)
                 setter_extra = lambda _=None: async_thread.run(db.update_label(label, "name"))
                 if changed:
@@ -4750,33 +4773,8 @@ class MainGUI():
                 if imgui.begin_popup_context_item(f"###label_name_{label.id}_context"):
                     utils.text_context(label, "name", setter_extra)
                     imgui.end_popup()
-                imgui.table_next_column()
-                imgui.set_cursor_pos_x(imgui.get_cursor_pos_x() + buttons_offset)
-                changed, value = imgui.color_edit3(f"###label_color_{label.id}", *label.color[:3], flags=imgui.COLOR_EDIT_NO_INPUTS)
-                if changed:
-                    label.color = (*value, 1.0)
-                    async_thread.run(db.update_label(label, "color"))
                 imgui.same_line()
-                if label_i == 0:
-                    imgui.push_disabled()
-                if imgui.button(f"{icons.arrow_up}###label_up_{label.id}", width=frame_height):
-                    swap = (label_i, label_i - 1)
-                if label_i == 0:
-                    imgui.pop_disabled()
-                imgui.same_line()
-                if label_i == len(Label.instances) - 1:
-                    imgui.push_disabled()
-                if imgui.button(f"{icons.arrow_down}###label_down_{label.id}", width=frame_height):
-                    swap = (label_i, label_i + 1)
-                if label_i == len(Label.instances) - 1:
-                    imgui.pop_disabled()
-                imgui.same_line()
-                if imgui.button(f"{icons.filter_plus_outline}###label_filter_{label.id}", width=frame_height):
-                    flt = Filter(FilterMode.Label)
-                    flt.match = label
-                    self.filters.append(flt)
-                imgui.same_line()
-                if imgui.button(f"{icons.trash_can_outline}###label_delete_{label.id}", width=frame_height):
+                if imgui.button(icons.trash_can_outline, width=frame_height):
                     async_thread.run(db.delete_label(label))
 
             if swap:

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -4774,8 +4774,9 @@ class MainGUI():
                 Label.instances[swap[0]], Label.instances[swap[1]] = Label.instances[swap[1]], Label.instances[swap[0]]
                 Label.update_positions()
                 for game in globals.games.values():
-                    game.labels.sort(key=lambda label: Label.instances.index(label))
-                async_thread.run(db.update_label_positions())
+                    game.labels.sort(key=lambda label: label.position)
+                positions = tuple((label.position, label.id) for label in Label.instances)
+                async_thread.run(db.update_label_positions(positions))
 
             draw_settings_label("New label:")
             if imgui.button("Add", width=right_width):

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -4775,8 +4775,7 @@ class MainGUI():
                 Label.update_positions()
                 for game in globals.games.values():
                     game.labels.sort(key=lambda label: label.position)
-                positions = tuple((label.position, label.id) for label in Label.instances)
-                async_thread.run(db.update_label_positions(positions))
+                async_thread.run(db.update_label_positions())
 
             draw_settings_label("New label:")
             if imgui.button("Add", width=right_width):


### PR DESCRIPTION
## Summary

- persist a user-controlled position for custom labels
- add move-up and move-down controls to the label settings UI
- keep loaded game badges synchronized with the global label order
- preserve legacy insertion order during the database migration

## Validation

- `python -m py_compile common/structs.py modules/db.py modules/gui.py`
- model-level assertions for sorting and contiguous position normalization
- verified `arrow-up` and `arrow-down` glyphs in the bundled Material Design icon font
