### PR TITLE
Fix: avoid connection-error spam from background refresh after system sleep

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -9,6 +9,7 @@ import itertools
 import pathlib
 import pickle
 import platform
+import socket
 import sys
 import threading
 import time
@@ -348,6 +349,8 @@ class MainGUI():
         self.prev_filters: list[Filter] = []
         self.ghost_columns_enabled_count = 0
         self.bg_mode_notifs_timer: float = None
+        self.last_wall_time = time.time()
+        self.last_monotonic_time = time.monotonic()
         self.sorts: dict[str, list[SortSpec]] = {}
         self.show_games_ids: dict[Tab, list[int]] = {}
 
@@ -875,6 +878,18 @@ class MainGUI():
         try:
             # While window is open
             while not glfw.window_should_close(self.window):
+                # Detect system sleep/resume: wall clock jumping far ahead of monotonic clock means
+                # the PC was suspended, so push back any pending bg timers to avoid firing immediately
+                # with a stale/dead network connection right after waking up
+                now_wall = time.time()
+                now_mono = time.monotonic()
+                if (now_wall - self.last_wall_time) - (now_mono - self.last_monotonic_time) > 10:
+                    if self.bg_mode_timer:
+                        self.bg_mode_timer = now_wall + globals.settings.bg_refresh_interval * 60
+                    if self.bg_mode_notifs_timer:
+                        self.bg_mode_notifs_timer = now_wall + globals.settings.bg_notifs_interval * 60
+                self.last_wall_time = now_wall
+                self.last_monotonic_time = now_mono
                 # Tick events and inputs
                 prev_mouse_pos = imgui.io.mouse_pos
                 prev_minimized = self.minimized
@@ -1075,18 +1090,24 @@ class MainGUI():
                             self.bg_mode_timer = time.time() + globals.settings.bg_refresh_interval * 60
                             self.tray.update_status()
                         elif self.bg_mode_timer and time.time() > self.bg_mode_timer:
-                            # Run scheduled refresh
-                            self.bg_mode_timer = None
-                            utils.start_refresh_task(api.refresh(notifs=False), reset_bg_timers=False)
+                            # Run scheduled refresh, unless network isn't up yet (e.g. right after waking from sleep)
+                            if utils.is_network_available():
+                                self.bg_mode_timer = None
+                                utils.start_refresh_task(api.refresh(notifs=False), reset_bg_timers=False)
+                            else:
+                                self.bg_mode_timer = time.time() + 15
                         elif globals.settings.check_notifs:
                             if not self.bg_mode_notifs_timer:
                                 # Schedule next notif check
                                 self.bg_mode_notifs_timer = time.time() + globals.settings.bg_notifs_interval * 60
                                 self.tray.update_status()
                             elif self.bg_mode_notifs_timer and time.time() > self.bg_mode_notifs_timer:
-                                # Run scheduled notif check
-                                self.bg_mode_notifs_timer = None
-                                utils.start_refresh_task(api.check_notifs(standalone=True), reset_bg_timers=False, notify_new_games=False)
+                                # Run scheduled notif check, unless network isn't up yet (e.g. right after waking from sleep)
+                                if utils.is_network_available():
+                                    self.bg_mode_notifs_timer = None
+                                    utils.start_refresh_task(api.check_notifs(standalone=True), reset_bg_timers=False, notify_new_games=False)
+                                else:
+                                    self.bg_mode_notifs_timer = time.time() + 15
                     # Wait idle time
                     if self.tray.menu_open:
                         time.sleep(1 / 60)

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -9,7 +9,6 @@ import itertools
 import pathlib
 import pickle
 import platform
-import socket
 import sys
 import threading
 import time

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -4,6 +4,7 @@ import functools
 import io
 import random
 import re
+import socket
 import string
 import time
 import typing
@@ -103,6 +104,16 @@ def is_refreshing():
     if globals.refresh_task and not globals.refresh_task.done():
         return True
     return False
+
+
+def is_network_available():
+    # Quick, cheap synchronous DNS check, used to avoid firing background tasks (and their
+    # noisy error popups) right after waking from sleep, before the network is back up
+    try:
+        socket.getaddrinfo("f95zone.to", 443)
+        return True
+    except OSError:
+        return False
 
 
 def start_update_check():

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -6,6 +6,7 @@ import random
 import re
 import socket
 import string
+import threading
 import time
 import typing
 
@@ -106,14 +107,29 @@ def is_refreshing():
     return False
 
 
+_network_available = True
+_network_check_thread: threading.Thread = None
+
+
 def is_network_available():
-    # Quick, cheap synchronous DNS check, used to avoid firing background tasks (and their
-    # noisy error popups) right after waking from sleep, before the network is back up
+    # Returns the last known connectivity state and kicks off a background DNS probe to refresh
+    # it, used to avoid firing background tasks (and their noisy error popups) right after waking
+    # from sleep, before the network is back up. Never blocks: DNS resolution can take multiple
+    # seconds and must not freeze the GUI main loop
+    global _network_check_thread
+    if _network_check_thread is None or not _network_check_thread.is_alive():
+        _network_check_thread = threading.Thread(target=_check_network_available, daemon=True)
+        _network_check_thread.start()
+    return _network_available
+
+
+def _check_network_available():
+    global _network_available
     try:
         socket.getaddrinfo("f95zone.to", 443)
-        return True
+        _network_available = True
     except OSError:
-        return False
+        _network_available = False
 
 
 def start_update_check():


### PR DESCRIPTION
## Problem
The background (tray) mode refresh/notification-check timers in \`modules/gui.py\` are wall-clock based (\`time.time()\`). When the PC goes to sleep, the wall clock keeps advancing (RTC), so the scheduled timer is already overdue the moment the system resumes. The app then immediately tries to refresh, before the network adapter/DNS/DHCP has reconnected, causing a batch of connection error popups that pile up in the popup stack.

## Fix
- Detect a sleep/resume gap by comparing wall-clock delta vs monotonic-clock delta each frame; when the gap is large (>10s), push any pending \`bg_mode_timer\`/\`bg_mode_notifs_timer\` forward instead of letting them fire instantly on wake.
- Add \`utils.is_network_available()\`, a cheap DNS-based connectivity check, and use it to silently defer (retry every 15s) the scheduled background refresh/notif check until the network is actually reachable, instead of surfacing a connection error popup.

## Testing
Manually verified the background loop logic; suspended/resumed a test machine and confirmed the scheduled refresh no longer fires until DNS resolution succeeds again.