### PR TITLE
Fix missing icon on Wayland

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -396,6 +396,7 @@ class MainGUI():
         glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)  # OS X supports only forward-compatible core profiles from 3.2
         glfw.window_hint(glfw.VISIBLE, False)
+        glfw.window_hint_string(glfw.WAYLAND_APP_ID, "F95Checker")
 
         # Create a windowed mode window and its OpenGL context
         self.window: glfw._GLFWwindow = glfw.create_window(*size, "F95Checker", None, None)


### PR DESCRIPTION
Add App ID so process is linked to desktop metadata.

### Before

<img width="1366" height="768" alt="Screenshot From 2026-08-29 23-23-31" src="https://github.com/user-attachments/assets/5a5352d0-5672-4f8b-aafc-b3a912463d15" />

### After

<img width="1366" height="768" alt="Screenshot From 2026-08-29 23-30-13" src="https://github.com/user-attachments/assets/5b18feec-6c18-4b06-9336-27c265aecb13" />