### PR TITLE
fix missing preview images

### DIFF
--- a/common/parser.py
+++ b/common/parser.py
@@ -222,7 +222,7 @@ def thread(res: bytes) -> ParsedThread | ParserError:
         for elem in html.find(is_class("p-title-value")).children:
             if not is_class("labelLink")(elem) and not is_class("label-append")(elem):
                 name += elem.text
-        name = fixed_spaces(sanitize_whitespace(re.search(r"^\s*(.*?)(?:\s*\[.*?\]\s*)*$", name).group(1)))
+        name = fixed_spaces(sanitize_whitespace(re.search(r"^\s*(.*?)(?:\s*\[.*?\]\s*)*$", name, re.DOTALL).group(1)).replace("\n", " "))
 
         thread_version = get_game_attr("version", "mod version", "game version")
         if not thread_version:
@@ -405,8 +405,20 @@ def thread(res: bytes) -> ParsedThread | ParserError:
         else:
             image_url = "missing"
 
-        # FIXME: find preview images in thread
+        # Find all preview images in the starter post, prefer the full-size URL
         previews_urls = []
+        for img in post.find(is_class("bbWrapper")).find_all("img"):
+            if img.find_parent("noscript"):
+                continue
+            url = img.get("data-src") or img.get("src") or ""
+            if not url.startswith("https://attachments."):
+                continue
+            # The wrapper link points at the full-size image, the img at a thumbnail
+            if (link := img.find_parent("a")) is not None and (href := link.get("href") or "").startswith("https://attachments."):
+                url = href
+            url = url.replace("/thumb/", "/", 1)
+            if url not in previews_urls:
+                previews_urls.append(url)
 
         downloads = get_game_downloads("downloads", "download")
 

--- a/common/parser.py
+++ b/common/parser.py
@@ -417,7 +417,8 @@ def thread(res: bytes) -> ParsedThread | ParserError:
             if (link := img.find_parent("a")) is not None and (href := link.get("href") or "").startswith("https://attachments."):
                 url = href
             url = url.replace("/thumb/", "/", 1)
-            if url not in previews_urls:
+            # Skip the cover image and duplicates
+            if url != image_url and url not in previews_urls:
                 previews_urls.append(url)
 
         downloads = get_game_downloads("downloads", "download")

--- a/indexer/scraper.py
+++ b/indexer/scraper.py
@@ -111,10 +111,11 @@ async def thread(id: int) -> dict[str, str] | f95zone.IndexerError | None:
                     ret.developer = update["creator"] or ret.developer
                     ret.score = round(update["rating"], 1)
                     ret.image_url = parser.attachment(update["cover"]) or ret.image_url
-                    ret.previews_urls = [
-                        parser.attachment(preview_url)
-                        for preview_url in update["screens"]
-                    ] or ret.previews_urls
+                    # Append screens from latest updates that are missing in the thread
+                    for preview_url in update["screens"]:
+                        preview_url = parser.attachment(preview_url)
+                        if preview_url not in ret.previews_urls:
+                            ret.previews_urls.append(preview_url)
                     last_promoted = parser.datestamp(update["ts"])
                     if (
                         ret.last_updated > time.time()  # Only if thread has a typo


### PR DESCRIPTION
FIXED: FIXME in `common/parser.py` - Finds all preview images and caches URLs
ADJUSTED: name-regex in `common/parser.py` to account for '\n' in game title
UPDATED: `indexer/scraper.py` - Appends new images to those added by `common/parser.py`

This commit contains the following changes:
    common/parser.py   | 16 ++++++++++++++--
    indexer/scraper.py |  9 +++++----
    2 files changed, 19 insertions(+), 6 deletions(-)